### PR TITLE
Enable progress reporting for ios.

### DIFF
--- a/ios/Plugin/SimpleSessionExporter.swift
+++ b/ios/Plugin/SimpleSessionExporter.swift
@@ -29,6 +29,8 @@ open class SimpleSessionExporter: NSObject {
         self.asset = asset
     }
     
+    private var exportSession: AVAssetExportSession?;
+    
     public override init() {
         self.timeRange = CMTimeRange(start: CMTime.zero, end: CMTime.positiveInfinity)
         super.init()
@@ -45,6 +47,12 @@ extension SimpleSessionExporter {
     
     /// Completion handler type for when an export finishes.
     public typealias CompletionHandler = (_ status: AVAssetExportSession.Status) -> Void
+    
+    var progress: Float {
+        get {
+            self.exportSession?.progress ?? 0.0;
+        }
+    }
     
     /// Initiates an export session.
     ///
@@ -134,13 +142,16 @@ extension SimpleSessionExporter {
         export.videoComposition = videoComposition
         export.outputFileType = outputFileType
         export.outputURL = outputURL
+        self.exportSession = export
         
         export.exportAsynchronously {
             DispatchQueue.main.async {
                 switch export.status {
                 case .completed:
+                    self.exportSession = nil
                     completionHandler(.completed)
                 default:
+                    self.exportSession = nil
                     print("Something went wrong during export.")
                     print(export.error ?? "unknown error")
                     completionHandler(.failed)

--- a/ios/Plugin/VideoEditor.swift
+++ b/ios/Plugin/VideoEditor.swift
@@ -42,8 +42,17 @@ import UIKit
             AVVideoHeightKey: NSNumber(integerLiteral: Int(targetVideoSize.height)),
         ]
         
+        let progressUpdater = DispatchQueue.main.schedule(
+            after: .init(.now()),
+            interval: .milliseconds(250),
+            {
+                progressHandler(exporter.progress)
+            }
+        )
+        
         exporter.export(
             completionHandler: { status in
+                progressUpdater.cancel()
                 switch status {
                 case .completed:
                     completionHandler(exporter.outputURL!)


### PR DESCRIPTION
Modifies the SimpleSessionExporter to expose a progress Float value. This Float value defaults to 0 if there is no exportSession. A new exportSession private var was added to store the current exportSession. The AVAssetExportSession completion handler updates the exportSession reference to nil once it has completed.

To actually send the updates, we add a schedule job every 250 milliseconds which calls our progressHandler. The exporter completion handler cancels it when it is done.

This PR aims to address issue #10