### PR TITLE
Feat: Android 13 Support

### DIFF
--- a/android/src/main/java/com/whiteguru/capacitor/plugin/videoeditor/VideoEditorPlugin.java
+++ b/android/src/main/java/com/whiteguru/capacitor/plugin/videoeditor/VideoEditorPlugin.java
@@ -3,6 +3,7 @@ package com.whiteguru.capacitor.plugin.videoeditor;
 import android.Manifest;
 import android.content.Context;
 import android.net.Uri;
+import android.os.Build;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -16,8 +17,6 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.annotation.PermissionCallback;
-
-import android.util.Log;
 
 import com.linkedin.android.litr.analytics.TrackTransformationInfo;
 import com.linkedin.android.litr.TransformationListener;
@@ -51,6 +50,8 @@ public class VideoEditorPlugin extends Plugin {
 
     // Message constants
     private static final String PERMISSION_DENIED_ERROR_STORAGE = "User denied access to storage";
+    private static final String STORAGE_PERMISSION = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU ? MEDIA_VIDEO : STORAGE;
+
 
     @PluginMethod
     public void edit(PluginCall call) {
@@ -183,8 +184,8 @@ public class VideoEditorPlugin extends Plugin {
     }
 
     private boolean checkStoragePermissions(PluginCall call) {
-        if (getPermissionState(STORAGE) != PermissionState.GRANTED) {
-            requestPermissionForAlias(STORAGE, call, "storagePermissionsCallback");
+        if (getPermissionState(STORAGE_PERMISSION) != PermissionState.GRANTED) {
+            requestPermissionForAlias(STORAGE_PERMISSION, call, "storagePermissionsCallback");
             return false;
         }
         return true;
@@ -197,9 +198,8 @@ public class VideoEditorPlugin extends Plugin {
      */
     @PermissionCallback
     private void storagePermissionsCallback(PluginCall call) {
-        Log.d("TAG", "Swag and then the getPermissionState(STORAGE) result: " + getPermissionState(STORAGE));
-        if (getPermissionState(STORAGE) != PermissionState.GRANTED) {
-            Logger.debug(getLogTag(), "User denied photos permission: " + getPermissionState(STORAGE).toString());
+        if (getPermissionState(STORAGE_PERMISSION) != PermissionState.GRANTED) {
+            Logger.debug(getLogTag(), "User denied photos permission: " + getPermissionState(STORAGE_PERMISSION).toString());
             call.reject(PERMISSION_DENIED_ERROR_STORAGE);
             return;
         }

--- a/android/src/main/java/com/whiteguru/capacitor/plugin/videoeditor/VideoEditorPlugin.java
+++ b/android/src/main/java/com/whiteguru/capacitor/plugin/videoeditor/VideoEditorPlugin.java
@@ -17,6 +17,8 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.annotation.PermissionCallback;
 
+import android.util.Log;
+
 import com.linkedin.android.litr.analytics.TrackTransformationInfo;
 import com.linkedin.android.litr.TransformationListener;
 
@@ -33,13 +35,19 @@ import java.util.List;
                 @Permission(
                         strings = {Manifest.permission.READ_EXTERNAL_STORAGE},
                         alias = VideoEditorPlugin.STORAGE
+                ),
+                @Permission(
+                        strings = {Manifest.permission.READ_MEDIA_VIDEO},
+                        alias = VideoEditorPlugin.MEDIA_VIDEO
                 )
+
         }
 )
 public class VideoEditorPlugin extends Plugin {
 
     // Permission alias constants
     static final String STORAGE = "storage";
+    static final String MEDIA_VIDEO = "media_video";
 
     // Message constants
     private static final String PERMISSION_DENIED_ERROR_STORAGE = "User denied access to storage";
@@ -189,6 +197,7 @@ public class VideoEditorPlugin extends Plugin {
      */
     @PermissionCallback
     private void storagePermissionsCallback(PluginCall call) {
+        Log.d("TAG", "Swag and then the getPermissionState(STORAGE) result: " + getPermissionState(STORAGE));
         if (getPermissionState(STORAGE) != PermissionState.GRANTED) {
             Logger.debug(getLogTag(), "User denied photos permission: " + getPermissionState(STORAGE).toString());
             call.reject(PERMISSION_DENIED_ERROR_STORAGE);


### PR DESCRIPTION
Android SDKs target 13 or above require new permissions.

See: https://developer.android.com/about/versions/13/behavior-changes-13

This PR will support the new READ_MEDIA_VIDEO permission while leaving the READ_EXTERNAL_STORAGE for older operating systems to ensure backwards compatability.