### PR TITLE
Fix time problem of output video

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
 
-    implementation 'com.linkedin.android.litr:litr:1.4.18'
+    implementation 'com.linkedin.android.litr:litr:1.5.5'
 
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/android/src/main/java/com/whiteguru/capacitor/plugin/videoeditor/VideoEditorLitr.java
+++ b/android/src/main/java/com/whiteguru/capacitor/plugin/videoeditor/VideoEditorLitr.java
@@ -66,6 +66,7 @@ public class VideoEditorLitr {
         TransformationOptions transformationOptions = new TransformationOptions.Builder()
                 .setGranularity(MediaTransformer.GRANULARITY_DEFAULT)
                 .setSourceMediaRange(new MediaRange(startsAtUs, endsAtUs))
+                .setRemoveMetadata(true)
                 .build();
 
         // Video codec config


### PR DESCRIPTION
If I trim 30s to 40s of original video, output only has 10 seconds, but it will start from 30s and the video can't play successfully.
I change LiTr version, and add setRemoveMetadata and the problem is solved.