### PR TITLE
Add homepage package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "type": "git",
     "url": "git+https://github.com/dragermrb/capacitor-plugin-video-editor.git"
   },
+  "homepage": "https://github.com/dragermrb/capacitor-plugin-video-editor#readme",
   "name": "@whiteguru/capacitor-plugin-video-editor",
   "bugs": {
     "url": "https://github.com/dragermrb/capacitor-plugin-video-editor/issues"


### PR DESCRIPTION
## Summary
- adds missing npm support/discovery metadata for `@whiteguru/capacitor-plugin-video-editor`
- updates only `package.json`

## Metadata added
- `homepage`: `https://github.com/dragermrb/capacitor-plugin-video-editor#readme`

## Validation
- parsed `package.json` as JSON after the change
- confirmed the manifest still has `name: @whiteguru/capacitor-plugin-video-editor`
- checked this is metadata-only: no runtime code, dependencies, exports, generated assets, or build behavior changed

This small metadata fix makes the published npm package expose the project support/discovery information once the package is next released.